### PR TITLE
Systemd service file example

### DIFF
--- a/system.d/power-calculator.service
+++ b/system.d/power-calculator.service
@@ -1,4 +1,4 @@
-f[Unit]
+[Unit]
 Description=powercalculator
 After=syslog.target network.target ntp.service
 

--- a/system.d/power-calculator.service
+++ b/system.d/power-calculator.service
@@ -1,0 +1,11 @@
+f[Unit]
+Description=powercalculator
+After=syslog.target network.target ntp.service
+
+[Service]
+ExecStart=/usr/local/bin/PowerCalculator --config /home/pi/calculator-config/Domainlogic.json --vzloggerconf /home/pi/calculator-config/Vzlogger.json --log /home/pi/calculator-config/logfile.log --debug
+ExecReload=
+StandardOutput=null
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The `PowerCalculator` executable should be symbolically linked to /usr/local/bin for this to work.